### PR TITLE
Remove trailing slash from url if it is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 test-app.js
 .idea/
+*.sw[op]

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ let Storage = function (options) {
     };
     return checkAuth()
       .then(() => {
-        options.url = this.session.url + options.url;
+        let hasTrailingSlash = /\/$/.test(this.session.url);
+        options.url = (hasTrailingSlash ? this.session.url.slice(0, -1) : this.session.url) + options.url;
         if (!options.headers) {
           options.headers = {};
         }


### PR DESCRIPTION
From selectel docs:
https://support.selectel.ru/storage/api_info/#id14
```
# вывод curl сокращен в целях удобочитаемости
> HTTP/1.1 204 No Content
> X-Expire-Auth-Token: 86029
> X-Storage-Url: https://xxx.selcdn.ru/
> X-Auth-Token: 285a05936fe0817beac78e84ad2c5f12
```
Notice trailing slash in `X-Storage-Url` field.